### PR TITLE
Support emacsclient options

### DIFF
--- a/Org Protocol Handler.app/Contents/Resources/parse.py
+++ b/Org Protocol Handler.app/Contents/Resources/parse.py
@@ -11,7 +11,14 @@ import urlparse
 def read_config():
     ini_path = os.path.expanduser("~/.orgprotocol.ini")
     config = ConfigParser.ConfigParser()
-    config.read([ini_path])
+    try:
+        config.read([ini_path])
+    except Exception:
+        print("Error reading %s" % ini_path)
+    return config
+
+
+def emacs_client_command(config):
     path = emacsclient_path(config)
     options = emacsclient_options(config)
     cmd = path + options
@@ -86,7 +93,8 @@ def main():
 
     url = sys.argv[1]
     raw_url = urllib.unquote(url)
-    cmd = read_config()
+    config = read_config()
+    cmd = emacs_client_command(config)
     cmd.append(raw_url)
     subprocess.check_output(cmd)
     print(get_title(url, is_old_style_link(url)))

--- a/Org Protocol Handler.app/Contents/Resources/parse.py
+++ b/Org Protocol Handler.app/Contents/Resources/parse.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
-import sys
-import urlparse
-import urllib
-import subprocess
-import os
 import ConfigParser
+import os
+import subprocess
+import sys
+import urllib
+import urlparse
 
 
 def read_config():


### PR DESCRIPTION
This fixes one of the limitations I ran into while trying to use this app:  allowing passing options to `emacsclient`.

The other problem I had, which is not addressed in this PR, was needing to change `python` to `python2.7.` in `main.scpt`.  It would be good to update the readme at the very least with a warning that `parse.py` is legacy python only.  Or better yet, refactor it to be version agnostic.  Maybe I will tackle that one next 😃 . Thanks for this, @aaronbieber!