### PR TITLE
Support python 2 and 3

### DIFF
--- a/Org Protocol Handler.app/Contents/Resources/parse.py
+++ b/Org Protocol Handler.app/Contents/Resources/parse.py
@@ -11,7 +11,14 @@ import urlparse
 def read_config():
     ini_path = os.path.expanduser("~/.orgprotocol.ini")
     config = ConfigParser.ConfigParser()
-    config.read([ini_path])
+    try:
+        config.read([ini_path])
+    except Exception:
+        print("Error reading %s" % ini_path)
+    return config
+
+
+def emacs_client_command(config):
     path = emacsclient_path(config)
     options = emacsclient_options(config)
     cmd = path + options
@@ -86,7 +93,8 @@ def main():
 
     url = sys.argv[1]
     raw_url = urllib.unquote(url)
-    cmd = read_config()
+    config = read_config()
+    cmd = emacs_client_command(config)
     cmd.append(raw_url)
     subprocess.check_output(cmd)
     print(get_title(url, is_old_style_link(url)))

--- a/Org Protocol Handler.app/Contents/Resources/parse.py
+++ b/Org Protocol Handler.app/Contents/Resources/parse.py
@@ -11,6 +11,7 @@ import six.moves.urllib.parse
 
 
 def read_config():
+    """Read and parse ~/.orgprotocol.ini if it exists."""
     ini_path = os.path.expanduser("~/.orgprotocol.ini")
     config = six.moves.configparser.ConfigParser()
     try:
@@ -21,6 +22,10 @@ def read_config():
 
 
 def emacs_client_command(config):
+    """Construct a list, each member of which is a part of the
+    `emacsclient` command to be run by `subprocess` and used in
+    main.scpt. Provides the default `emacsclient` executable if
+    ~/.orgprotocol.ini doesn't exist."""
     path = emacsclient_path(config)
     options = emacsclient_options(config)
     cmd = path + options
@@ -31,16 +36,18 @@ def emacsclient_path(config):
     """Get the configured path to `emacsclient`, or the default."""
     try:
         path = config.get("emacsclient", "path")
-    except Exception as e:
+    except Exception:
         path = "/usr/local/bin/emacsclient"
     return [path]
 
 
 def emacsclient_options(config):
-    """Unpack options from config file"""
+    """Unpack options from config file.  Options are appeneded to the final
+    `emacsclient` command.  Returns an empty list if no options are specified.
+    """
     try:
-        return list(dict(config.items('options')).values())
-    except Exception as e:
+        return list(dict(config.items("options")).values())
+    except Exception:
         return []
 
 

--- a/Org Protocol Handler.app/Contents/Resources/parse.py
+++ b/Org Protocol Handler.app/Contents/Resources/parse.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
-import sys
-import urlparse
-import urllib
-import subprocess
-import os
 import ConfigParser
+import os
+import subprocess
+import sys
+import urllib
+import urlparse
 
 
 def read_config():

--- a/Org Protocol Handler.app/Contents/Resources/parse.py
+++ b/Org Protocol Handler.app/Contents/Resources/parse.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python
 
-import ConfigParser
+from __future__ import print_function
+from __future__ import absolute_import
+from six.moves import configparser
 import os
 import subprocess
 import sys
-import urllib
-import urlparse
+import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
+import six.moves.urllib.parse
 
 
 def read_config():
     ini_path = os.path.expanduser("~/.orgprotocol.ini")
-    config = ConfigParser.ConfigParser()
+    config = six.moves.configparser.ConfigParser()
     try:
         config.read([ini_path])
     except Exception:
@@ -29,7 +31,7 @@ def emacsclient_path(config):
     """Get the configured path to `emacsclient`, or the default."""
     try:
         path = config.get("emacsclient", "path")
-    except Exception, e:
+    except Exception as e:
         path = "/usr/local/bin/emacsclient"
     return [path]
 
@@ -37,8 +39,8 @@ def emacsclient_path(config):
 def emacsclient_options(config):
     """Unpack options from config file"""
     try:
-        return dict(config.items('options')).values()
-    except Exception, e:
+        return list(dict(config.items('options')).values())
+    except Exception as e:
         return []
 
 
@@ -56,15 +58,15 @@ def is_old_style_link(url):
 
 def get_new_style_title(url):
     """Get the title from a new style URL."""
-    url_fragments = urlparse.urlparse(url)
+    url_fragments = six.moves.urllib.parse.urlparse(url)
 
     # url_fragments is a 6 tuple; index 4 is the querystring
     if not len(url_fragments[4]):
         return ""
 
-    qs_parts = urlparse.parse_qs(url_fragments[4])
+    qs_parts = six.moves.urllib.parse.parse_qs(url_fragments[4])
 
-    if "title" in qs_parts.keys() and len(qs_parts["title"]):
+    if "title" in list(qs_parts.keys()) and len(qs_parts["title"]):
         return qs_parts["title"][0]
 
     return ""
@@ -72,10 +74,10 @@ def get_new_style_title(url):
 
 def get_old_style_title(url):
     """Get the title from an old style URL."""
-    url_fragments = urlparse.urlparse(url)
+    url_fragments = six.moves.urllib.parse.urlparse(url)
 
     path_parts = url_fragments[2].split("/")
-    return urllib.unquote(path_parts[4])
+    return six.moves.urllib.parse.unquote(path_parts[4])
 
 
 def get_title(url, is_old_style=True):
@@ -92,7 +94,7 @@ def main():
         sys.exit(1)
 
     url = sys.argv[1]
-    raw_url = urllib.unquote(url)
+    raw_url = six.moves.urllib.parse.unquote(url)
     config = read_config()
     cmd = emacs_client_command(config)
     cmd.append(raw_url)

--- a/Org Protocol Handler.app/Contents/Resources/parse.py
+++ b/Org Protocol Handler.app/Contents/Resources/parse.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-from __future__ import absolute_import
-from six.moves import configparser
+from __future__ import absolute_import, print_function
+
 import os
 import subprocess
 import sys
-import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
-import six.moves.urllib.parse
+
+import six.moves
 
 
 def read_config():


### PR DESCRIPTION
Not sure if this is considered best practice, but this branches off of https://github.com/aaronbieber/org-protocol-handler/pull/5 and fixes #6.  Only had to make one small change after running through [python-modernize](https://python-modernize.readthedocs.io/en/latest/).  I avoided using [python-future](http://python-future.org/quickstart.html) since that ends up with a dependency on `future`.  `python-modernize` only relies on `six`.  So hopefully `six` is in fact installed by default on macOS.